### PR TITLE
Added Unit Filter to Roster

### DIFF
--- a/Destruction - Gloomspite Gitz.cat
+++ b/Destruction - Gloomspite Gitz.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="98" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="145" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="99" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="144" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="3323-8984-c803-feb5" name="Gloomspite Errata/Points, July 2019"/>
     <publication id="0dee-8846-061a-5504" name="White Dwarf - Issue 455" shortName="White Dwarf" publisher="Issue 455" publicationDate="August 2020"/>
@@ -97,17 +97,65 @@
     <entryLink id="d894-1877-e48a-d85d" name="Madcap Shaman" hidden="false" collective="false" import="true" targetId="4456-155d-685b-bd18" type="selectionEntry"/>
     <entryLink id="7c8d-2f3d-67f0-7e04" name="Loonsmasha Fanatics" hidden="false" collective="false" import="true" targetId="b1a7-92f3-64d3-91f1" type="selectionEntry"/>
     <entryLink id="1a9a-5dad-68e2-bc3c" name="Battalion: Troggherd" hidden="false" collective="false" import="true" targetId="cfa0-bc57-427f-dac8" type="selectionEntry"/>
-    <entryLink id="b583-cda5-78cc-82b3" name="Boingrot Bounders" hidden="false" collective="false" import="true" targetId="ff2e-4400-dbde-d4c4" type="selectionEntry"/>
+    <entryLink id="b583-cda5-78cc-82b3" name="Boingrot Bounders" hidden="false" collective="false" import="true" targetId="ff2e-4400-dbde-d4c4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="403d-f219-0811-551b" name="Zarbag&apos;s Gitz" hidden="false" collective="false" import="true" targetId="2653-d92c-7afc-5bf6" type="selectionEntry"/>
     <entryLink id="2fa8-e4d0-5fd3-fd08" name="Zarbag" hidden="false" collective="false" import="true" targetId="db84-4cbf-0008-9a63" type="selectionEntry"/>
     <entryLink id="4e28-9e45-8827-ceed" name="Stabbas" hidden="false" collective="false" import="true" targetId="f468-427a-bd3b-4e91" type="selectionEntry"/>
-    <entryLink id="bf3f-bc48-52cb-d3eb" name="Fellwater Troggoths" hidden="false" collective="false" import="true" targetId="1532-280f-10d7-576e" type="selectionEntry"/>
-    <entryLink id="90c2-6206-9d63-9e26" name="Loonboss on Giant Cave Squig" hidden="false" collective="false" import="true" targetId="8616-ec44-afd5-57d3" type="selectionEntry"/>
+    <entryLink id="bf3f-bc48-52cb-d3eb" name="Fellwater Troggoths" hidden="false" collective="false" import="true" targetId="1532-280f-10d7-576e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="68dd-522d-b18f-31e0" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="90c2-6206-9d63-9e26" name="Loonboss on Giant Cave Squig" hidden="false" collective="false" import="true" targetId="8616-ec44-afd5-57d3" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="6f25-ea08-dace-8ae7" name="Rippa&apos;s Snarlfangs" hidden="false" collective="false" import="true" targetId="d396-97ee-2cbd-c311" type="selectionEntry"/>
-    <entryLink id="aaea-fa97-38a2-2db1" name="Spider Riders" hidden="false" collective="false" import="true" targetId="f71c-25f7-10fd-9f8e" type="selectionEntry"/>
+    <entryLink id="aaea-fa97-38a2-2db1" name="Spider Riders" hidden="false" collective="false" import="true" targetId="f71c-25f7-10fd-9f8e" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="422a-6e28-ba13-c4d3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="4094-9df8-1e66-bbb3" name="Loonboss" hidden="false" collective="false" import="true" targetId="d7de-3092-1abc-b208" type="selectionEntry"/>
-    <entryLink id="8d20-a798-f03a-d4a6" name="Squig Herd" hidden="false" collective="false" import="true" targetId="d7f2-6558-9c0f-89bc" type="selectionEntry"/>
-    <entryLink id="508e-ba2b-6530-65db" name="Aleguzzler Gargant" hidden="false" collective="false" import="true" targetId="9353-2c1a-a365-7fcd" type="selectionEntry"/>
+    <entryLink id="8d20-a798-f03a-d4a6" name="Squig Herd" hidden="false" collective="false" import="true" targetId="d7f2-6558-9c0f-89bc" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="508e-ba2b-6530-65db" name="Aleguzzler Gargant" hidden="false" collective="false" import="true" targetId="9353-2c1a-a365-7fcd" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c4e0-4660-05a1-8a17" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="2e34-4297-2fc7-b0fd" name="Allegiance" hidden="false" collective="false" import="true" targetId="b612-c701-be32-d00d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -117,28 +165,164 @@
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="e3d8-8996-c8eb-2f52" name="Arachnarok Spider with Flinger" hidden="false" collective="false" import="true" targetId="aa89-7439-46a3-15cf" type="selectionEntry"/>
-    <entryLink id="b4b1-6c46-18ca-e7d2" name="Arachnarok Spider with Spiderfang Warparty" hidden="false" collective="false" import="true" targetId="5733-02d6-236b-4cbf" type="selectionEntry"/>
+    <entryLink id="e3d8-8996-c8eb-2f52" name="Arachnarok Spider with Flinger" hidden="false" collective="false" import="true" targetId="aa89-7439-46a3-15cf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="422a-6e28-ba13-c4d3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="b4b1-6c46-18ca-e7d2" name="Arachnarok Spider with Spiderfang Warparty" hidden="false" collective="false" import="true" targetId="5733-02d6-236b-4cbf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="422a-6e28-ba13-c4d3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="5add-83c4-3432-4c3f" name="Bad Moon Loonshrine" hidden="false" collective="false" import="true" targetId="923f-6761-574a-0688" type="selectionEntry"/>
-    <entryLink id="9c0b-0d90-35a3-b122" name="Colossal Squig" hidden="false" collective="false" import="true" targetId="48cd-dd8f-5a2d-5e99" type="selectionEntry"/>
-    <entryLink id="2bc5-6b05-08b9-ea49" name="Dankhold Troggoth" hidden="false" collective="false" import="true" targetId="c0f3-c879-d068-32af" type="selectionEntry"/>
+    <entryLink id="9c0b-0d90-35a3-b122" name="Colossal Squig" hidden="false" collective="false" import="true" targetId="48cd-dd8f-5a2d-5e99" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="2bc5-6b05-08b9-ea49" name="Dankhold Troggoth" hidden="false" collective="false" import="true" targetId="c0f3-c879-d068-32af" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="68dd-522d-b18f-31e0" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="04ca-f4e4-7e08-496a" name="Fungoid Cave-Shaman" hidden="false" collective="false" import="true" targetId="6d41-0a01-8e38-6094" type="selectionEntry"/>
     <entryLink id="7bd4-e7f4-817b-98f5" name="Gobbapalooza" hidden="false" collective="false" import="true" targetId="649e-bb80-2cdb-9589" type="selectionEntry"/>
-    <entryLink id="f5ba-3dd8-de2e-78fa" name="Loonboss on Mangler Squigs" hidden="false" collective="false" import="true" targetId="6a0d-90f0-a499-dfbb" type="selectionEntry"/>
-    <entryLink id="023e-8fef-ab0d-9dc9" name="Loonboss with Giant Cave Squig" hidden="false" collective="false" import="true" targetId="2374-5617-853d-cc95" type="selectionEntry"/>
-    <entryLink id="8f64-1108-617d-49f0" name="Mangler Squigs" hidden="false" collective="false" import="true" targetId="ebf9-d4df-0661-726d" type="selectionEntry"/>
-    <entryLink id="55db-cd60-7a7a-a163" name="Mollog" hidden="false" collective="false" import="true" targetId="857e-08ce-74a7-043f" type="selectionEntry"/>
-    <entryLink id="521b-671b-be27-575b" name="Scuttleboss on Gigantic Spider" hidden="false" collective="false" import="true" targetId="acdd-a781-ffe2-69b1" type="selectionEntry"/>
-    <entryLink id="2325-cbc8-d512-0e11" name="Skitterstrand Arachnarok" hidden="false" collective="false" import="true" targetId="3e7f-35df-5a5d-0b38" type="selectionEntry"/>
+    <entryLink id="f5ba-3dd8-de2e-78fa" name="Loonboss on Mangler Squigs" hidden="false" collective="false" import="true" targetId="6a0d-90f0-a499-dfbb" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="023e-8fef-ab0d-9dc9" name="Loonboss with Giant Cave Squig" hidden="false" collective="false" import="true" targetId="2374-5617-853d-cc95" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="8f64-1108-617d-49f0" name="Mangler Squigs" hidden="false" collective="false" import="true" targetId="ebf9-d4df-0661-726d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="55db-cd60-7a7a-a163" name="Mollog" hidden="false" collective="false" import="true" targetId="857e-08ce-74a7-043f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="68dd-522d-b18f-31e0" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="521b-671b-be27-575b" name="Scuttleboss on Gigantic Spider" hidden="false" collective="false" import="true" targetId="acdd-a781-ffe2-69b1" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="422a-6e28-ba13-c4d3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="2325-cbc8-d512-0e11" name="Skitterstrand Arachnarok" hidden="false" collective="false" import="true" targetId="3e7f-35df-5a5d-0b38" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="422a-6e28-ba13-c4d3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="769c-213a-a559-9692" name="Skragrott, the Loonking" hidden="false" collective="false" import="true" targetId="a2bb-637e-6b79-4ea3" type="selectionEntry"/>
-    <entryLink id="b067-d8cd-64cb-2ce1" name="Sneaky Snufflers" hidden="false" collective="false" import="true" targetId="7f2d-e883-6fb0-ef8b" type="selectionEntry"/>
+    <entryLink id="b067-d8cd-64cb-2ce1" name="Sneaky Snufflers" hidden="false" collective="false" import="true" targetId="7f2d-e883-6fb0-ef8b" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="db10-bc42-a04c-45f1" name="Sporesplatta Fanatics" hidden="false" collective="false" import="true" targetId="3469-bad7-6b85-14b7" type="selectionEntry"/>
-    <entryLink id="4b2b-d7af-642b-85c5" name="Squig Gobba" hidden="false" collective="false" import="true" targetId="4a2d-0812-1be1-cc52" type="selectionEntry"/>
-    <entryLink id="19c7-4f2e-b279-e1d4" name="Squig Hoppers" hidden="false" collective="false" import="true" targetId="73c2-8a55-9faa-bb56" type="selectionEntry"/>
-    <entryLink id="2e83-387c-3c8e-a77f" name="Troggoth Hag" hidden="false" collective="false" import="true" targetId="39db-30e2-d877-afce" type="selectionEntry"/>
-    <entryLink id="2242-65ba-9312-d2b3" name="Webspinner Shaman" hidden="false" collective="false" import="true" targetId="61af-737d-a504-8955" type="selectionEntry"/>
-    <entryLink id="e0f1-dc7e-f637-04b3" name="Webspinner Shaman on Arachnarok Spider" hidden="false" collective="false" import="true" targetId="27a1-4c07-2d2a-0b46" type="selectionEntry"/>
-    <entryLink id="8ebb-8b7b-e71c-85d2" name="Bonegrinder Gargant" hidden="false" collective="false" import="true" targetId="bab8-af7f-af7e-ed87" type="selectionEntry"/>
+    <entryLink id="4b2b-d7af-642b-85c5" name="Squig Gobba" hidden="false" collective="false" import="true" targetId="4a2d-0812-1be1-cc52" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="19c7-4f2e-b279-e1d4" name="Squig Hoppers" hidden="false" collective="false" import="true" targetId="73c2-8a55-9faa-bb56" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6cfd-1c91-98ee-0d47" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="2e83-387c-3c8e-a77f" name="Troggoth Hag" hidden="false" collective="false" import="true" targetId="39db-30e2-d877-afce" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="68dd-522d-b18f-31e0" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="2242-65ba-9312-d2b3" name="Webspinner Shaman" hidden="false" collective="false" import="true" targetId="61af-737d-a504-8955" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="422a-6e28-ba13-c4d3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="e0f1-dc7e-f637-04b3" name="Webspinner Shaman on Arachnarok Spider" hidden="false" collective="false" import="true" targetId="27a1-4c07-2d2a-0b46" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="422a-6e28-ba13-c4d3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="8ebb-8b7b-e71c-85d2" name="Bonegrinder Gargant" hidden="false" collective="false" import="true" targetId="bab8-af7f-af7e-ed87" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c4e0-4660-05a1-8a17" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="0502-548a-3a9e-c2d3" name="Battalion: Gobbapalooza" hidden="false" collective="false" import="true" targetId="5a8d-7791-d79a-356a" type="selectionEntry"/>
     <entryLink id="b2de-282c-53ff-2e0d" name="Battalion: Skulkmob Horde" hidden="false" collective="false" import="true" targetId="4e4d-0bc4-c7d6-6eaf" type="selectionEntry"/>
     <entryLink id="98bc-f2f3-e8bd-81f5" name="Super Battalion: Squigalanche" hidden="false" collective="false" import="true" targetId="9928-67fe-9864-84ad" type="selectionEntry"/>
@@ -149,8 +333,24 @@
     <entryLink id="281d-2999-10f4-5ff1" name="Super Battalion: Spiderfang Stalktribe" hidden="false" collective="false" import="true" targetId="f39e-acf2-fa09-4b31" type="selectionEntry"/>
     <entryLink id="5171-e127-fddb-ef49" name="Battalion: Skitterstrand Nest" hidden="false" collective="false" import="true" targetId="306e-05ca-7807-93f2" type="selectionEntry"/>
     <entryLink id="fdcf-0d49-1d7b-3f1c" name="Shootas" hidden="false" collective="false" import="true" targetId="8599-239f-ebc7-8fcc" type="selectionEntry"/>
-    <entryLink id="51d1-2000-a124-4349" name="Dankhold Troggboss" hidden="false" collective="false" import="true" targetId="5a11-19e5-ab10-9fd6" type="selectionEntry"/>
-    <entryLink id="de32-abac-fb0e-c26c" name="Rockgut Troggoths" hidden="false" collective="false" import="true" targetId="5286-aa44-42ef-756f" type="selectionEntry"/>
+    <entryLink id="51d1-2000-a124-4349" name="Dankhold Troggboss" hidden="false" collective="false" import="true" targetId="5a11-19e5-ab10-9fd6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="68dd-522d-b18f-31e0" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="de32-abac-fb0e-c26c" name="Rockgut Troggoths" hidden="false" collective="false" import="true" targetId="5286-aa44-42ef-756f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="68dd-522d-b18f-31e0" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="fc38-9723-768d-c340" name="Battalion: Moon-jumper Stampede" hidden="false" collective="false" import="true" targetId="9470-dcb4-f996-0f8d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -169,9 +369,33 @@
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="4cab-663a-cadd-9560" name="One-Eyed Grunnock - Warstompa Mercenary" hidden="false" collective="false" import="true" targetId="40c7-4bb8-cfd9-7319" type="selectionEntry"/>
-    <entryLink id="e61c-1924-e367-191e" name="Big Drogg Fort-Kicka - Gatebreaker Mercenary" hidden="false" collective="false" import="true" targetId="8c3b-e825-efb0-25bd" type="selectionEntry"/>
-    <entryLink id="5b62-7885-d7e6-0407" name="Bundo Whalebiter - Kraken-Eater Mercenary" hidden="false" collective="false" import="true" targetId="efae-6133-d899-a7e4" type="selectionEntry"/>
+    <entryLink id="4cab-663a-cadd-9560" name="One-Eyed Grunnock - Warstomper Mercenary" hidden="false" collective="false" import="true" targetId="40c7-4bb8-cfd9-7319" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c4e0-4660-05a1-8a17" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="e61c-1924-e367-191e" name="Big Drogg Fort-Kicka - Gatebreaker Mercenary" hidden="false" collective="false" import="true" targetId="8c3b-e825-efb0-25bd" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c4e0-4660-05a1-8a17" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="5b62-7885-d7e6-0407" name="Bundo Whalebiter - Kraken-Eater Mercenary" hidden="false" collective="false" import="true" targetId="efae-6133-d899-a7e4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c4e0-4660-05a1-8a17" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="e507-2411-f899-a0ae" name="Battalion: Stomping Megamob" hidden="false" collective="false" import="true" targetId="c7e0-93be-45e6-5c1f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -208,27 +432,132 @@
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="c8de-4ff5-f47e-4f94" name="Brawlsmasha - Bonegrinder Mercenary" hidden="false" collective="false" import="true" targetId="2f06-27c0-9f3d-40ad" type="selectionEntry"/>
+    <entryLink id="c8de-4ff5-f47e-4f94" name="Brawlsmasha - Bonegrinder Mercenary" hidden="false" collective="false" import="true" targetId="2f06-27c0-9f3d-40ad" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c4e0-4660-05a1-8a17" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="ea2f-c76d-217b-a3db" name="Kragnos, The End of Empires" hidden="false" collective="false" import="false" targetId="4eea-4e53-1088-fb6c" type="selectionEntry"/>
-    <entryLink id="34ce-35fc-a334-bf22" name="Doom Diver Catapult [LEGENDS]" hidden="false" collective="false" import="true" targetId="5431-4f62-923a-9f75" type="selectionEntry"/>
-    <entryLink id="a132-9c0f-d6fb-9b78" name="Grot Mob [LEGENDS]" hidden="false" collective="false" import="true" targetId="ba94-dc4e-039b-3838" type="selectionEntry"/>
-    <entryLink id="94c2-cc36-c0af-7518" name="Grot Rock Lobber [LEGENDS]" hidden="false" collective="false" import="true" targetId="cff4-a409-9918-fb14" type="selectionEntry"/>
-    <entryLink id="e04c-eff5-b41f-1f49" name="Grot Shaman [LEGENDS]" hidden="false" collective="false" import="true" targetId="1a06-cedd-69f6-070f" type="selectionEntry"/>
-    <entryLink id="0cfe-fb09-5669-24d3" name="Grot Spear Chukka [LEGENDS]" hidden="false" collective="false" import="true" targetId="8e9b-a990-86cc-e8ba" type="selectionEntry"/>
-    <entryLink id="07b4-6dee-db4f-b879" name="Grot Wolf Chariots [LEGENDS]" hidden="false" collective="false" import="true" targetId="e3d3-a5e4-e865-82d9" type="selectionEntry"/>
-    <entryLink id="5f6b-e979-d978-23f7" name="Grot Wolf Riders [LEGENDS]" hidden="false" collective="false" import="true" targetId="487a-7ff3-7262-e37a" type="selectionEntry"/>
-    <entryLink id="ad17-9dec-a9a7-6d56" name="Nasty Skulkers [LEGENDS]" hidden="false" collective="false" import="true" targetId="77f1-eb89-0e04-dd9b" type="selectionEntry"/>
-    <entryLink id="2e50-699b-63e2-f04f" name="Snotling Pump Wagon [LEGENDS]" hidden="false" collective="false" import="true" targetId="9dcb-ec97-6c7e-9ebf" type="selectionEntry"/>
-    <entryLink id="aefa-cc05-c33d-78ab" name="Snotlings [LEGENDS]" hidden="false" collective="false" import="true" targetId="e8f5-6356-2f1a-1d6b" type="selectionEntry"/>
-    <entryLink id="efcd-4bad-adad-a681" name="Sourbreath Troggoths [LEGENDS]" hidden="false" collective="false" import="true" targetId="8f33-49dc-8ff5-21b7" type="selectionEntry"/>
+    <entryLink id="34ce-35fc-a334-bf22" name="Doom Diver Catapult [LEGENDS]" hidden="false" collective="false" import="true" targetId="5431-4f62-923a-9f75" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="a132-9c0f-d6fb-9b78" name="Grot Mob [LEGENDS]" hidden="false" collective="false" import="true" targetId="ba94-dc4e-039b-3838" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="94c2-cc36-c0af-7518" name="Grot Rock Lobber [LEGENDS]" hidden="false" collective="false" import="true" targetId="cff4-a409-9918-fb14" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="e04c-eff5-b41f-1f49" name="Grot Shaman [LEGENDS]" hidden="false" collective="false" import="true" targetId="1a06-cedd-69f6-070f" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="0cfe-fb09-5669-24d3" name="Grot Spear Chukka [LEGENDS]" hidden="false" collective="false" import="true" targetId="8e9b-a990-86cc-e8ba" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="07b4-6dee-db4f-b879" name="Grot Wolf Chariots [LEGENDS]" hidden="false" collective="false" import="true" targetId="e3d3-a5e4-e865-82d9" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="5f6b-e979-d978-23f7" name="Grot Wolf Riders [LEGENDS]" hidden="false" collective="false" import="true" targetId="487a-7ff3-7262-e37a" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="ad17-9dec-a9a7-6d56" name="Nasty Skulkers [LEGENDS]" hidden="false" collective="false" import="true" targetId="77f1-eb89-0e04-dd9b" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="2e50-699b-63e2-f04f" name="Snotling Pump Wagon [LEGENDS]" hidden="false" collective="false" import="true" targetId="9dcb-ec97-6c7e-9ebf" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="aefa-cc05-c33d-78ab" name="Snotlings [LEGENDS]" hidden="false" collective="false" import="true" targetId="e8f5-6356-2f1a-1d6b" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
+    <entryLink id="efcd-4bad-adad-a681" name="Sourbreath Troggoths [LEGENDS]" hidden="false" collective="false" import="true" targetId="8f33-49dc-8ff5-21b7" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="51ce-c2f9-2e96-dadb" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="0518-7dfb-27c8-00da" name="Grand Strategy" hidden="false" collective="false" import="true" targetId="6283-1c2f-895a-2e14" type="selectionEntry"/>
     <entryLink id="d2f3-d24b-9c2e-872a" name="Endless Spell: Mork&apos;s Mighty Mushroom" hidden="false" collective="false" import="true" targetId="fcbc-c783-7e89-4a74" type="selectionEntry"/>
     <entryLink id="7af6-c8fd-55a9-764d" name="Endless Spell: Malevolent Moon" hidden="false" collective="false" import="true" targetId="30c6-9ad5-4148-2cc3" type="selectionEntry"/>
     <entryLink id="53b5-542b-813c-a472" name="Endless Spell: Scrapskuttle&apos;s Arachnacauldron" hidden="false" collective="false" import="true" targetId="9050-16f2-22bd-12b6" type="selectionEntry"/>
     <entryLink id="a3f1-cc18-66d5-ee32" name="Endless Spell: Scuttletide" hidden="false" collective="false" import="true" targetId="5a68-16ef-4275-58e1" type="selectionEntry"/>
-    <entryLink id="dc84-e5e0-ad87-cbff" name="Odo Godswallow - Beast-smasher Mercenary" hidden="false" collective="false" import="true" targetId="6373-4970-e2af-dd88" type="selectionEntry"/>
+    <entryLink id="dc84-e5e0-ad87-cbff" name="Odo Godswallow - Beast-smasher Mercenary" hidden="false" collective="false" import="true" targetId="6373-4970-e2af-dd88" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c4e0-4660-05a1-8a17" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
     <entryLink id="9b4a-e11e-2086-e158" name="Grinkrak the Great" hidden="false" collective="false" import="true" targetId="abf2-1ad3-e015-fee3" type="selectionEntry"/>
     <entryLink id="f737-d8c8-fe28-6dd5" name="Grinkrak&apos;s Looncourt" hidden="false" collective="false" import="true" targetId="f6f9-aee9-3912-1538" type="selectionEntry"/>
+    <entryLink id="14ba-ec27-e445-d620" name="Unit Filter" hidden="false" collective="false" import="true" targetId="08a2-91ae-86cd-d3a7" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="73c2-8a55-9faa-bb56" name="Squig Hoppers" hidden="false" collective="false" import="true" type="unit">
@@ -8339,6 +8668,38 @@ At the start of the combat phase, you can reveal 1 or more hidden NASTY SKULKERS
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="08a2-91ae-86cd-d3a7" name="Unit Filter" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="6dc7-9753-17e3-13e4" name="Game Options" hidden="false" targetId="1974-3f49-7f0b-8422" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c4e0-4660-05a1-8a17" name="Hide Gargant Units" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cb3-523f-e400-6278" type="max"/>
+          </constraints>
+        </selectionEntry>
+        <selectionEntry id="6cfd-1c91-98ee-0d47" name="Hide Squig Units" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c785-5a92-5388-c59c" type="max"/>
+          </constraints>
+        </selectionEntry>
+        <selectionEntry id="51ce-c2f9-2e96-dadb" name="Hide Legends Units" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fbc-66e1-c7e6-7d4a" type="max"/>
+          </constraints>
+        </selectionEntry>
+        <selectionEntry id="68dd-522d-b18f-31e0" name="Hide Troggoth Units" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="415b-3dbf-6e90-9f1a" type="max"/>
+          </constraints>
+        </selectionEntry>
+        <selectionEntry id="422a-6e28-ba13-c4d3" name="Hide Spiderfang Units" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a194-6511-cbfe-bc5c" type="max"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>


### PR DESCRIPTION
Added Unit Filter to allow easy hiding of units that match the following tags: SQUIG, TROGGOTH, SPIDERFANG, LEGENDS, GARGANT. Unit Filter is added to the Game Options section in the Root menu.